### PR TITLE
Comment by John on contact-points-using-clipping

### DIFF
--- a/_data/comments/contact-points-using-clipping/d5c1919c.yml
+++ b/_data/comments/contact-points-using-clipping/d5c1919c.yml
@@ -1,0 +1,5 @@
+id: d5c1919c
+date: 2021-11-30T14:38:16.1062572Z
+author: John
+avatar: https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y&s=96
+message: How is ref.max calculated? Read the comments and couldnt make sense of this value. Thank you, if you could prove code that related to the Edge struct this could be useful.


### PR DESCRIPTION
avatar: <img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y&s=96" width="64" height="64" />

How is ref.max calculated? Read the comments and couldnt make sense of this value. Thank you, if you could prove code that related to the Edge struct this could be useful.